### PR TITLE
[codex] Fix QuoteKit tests and random quote decoding

### DIFF
--- a/Sources/QuoteKit/APIs/QuoteAPIs.swift
+++ b/Sources/QuoteKit/APIs/QuoteAPIs.swift
@@ -7,6 +7,24 @@
 
 import Foundation
 
+private struct RandomQuoteResponse: Decodable {
+  let quote: Quote
+
+  enum CodingKeys: String, CodingKey {
+    case quote
+  }
+
+  init(from decoder: Decoder) throws {
+    if let quote = try? Quote(from: decoder) {
+      self.quote = quote
+      return
+    }
+
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    quote = try container.decode(Quote.self, forKey: .quote)
+  }
+}
+
 public extension QuoteKit {
   /// Fetches a single quote by its unique identifier.
   /// - Parameter id: The unique identifier of the quote.
@@ -122,7 +140,9 @@ public extension QuoteKit {
                                            type: type,
                                            authors: authors)
 
-    return try await execute(with: QuotableEndpoint(.randomQuote, queryItems: queryItems))
+    let response: RandomQuoteResponse = try await execute(
+      with: QuotableEndpoint(.randomQuote, queryItems: queryItems))
+    return response.quote
   }
 
   static private func randomQuoteParameters(minLength: Int? = nil,
@@ -198,7 +218,7 @@ public extension QuoteKit {
   /// - Returns: A `Quotes` collection with inspirational tags.
   /// - Throws: An error if the network request fails.
   static func inspirationalQuotes(limit: Int = 10, page: Int = 1) async throws -> Quotes {
-    try await quotes(tags: ["inspirational"], limit: limit, page: page)
+    try await quotes(tags: ["Inspirational"], limit: limit, page: page)
   }
   
   /// Fetches motivational quotes.

--- a/Sources/QuoteKit/Model/Author.swift
+++ b/Sources/QuoteKit/Model/Author.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct Author: Identifiable, Decodable, Sendable {
+public struct Author: Identifiable, Codable, Sendable {
   public var id: String
   public var link: String
   public var bio: String
@@ -37,6 +37,7 @@ extension Author {
   enum CodingKeys: String, CodingKey {
     case link, bio, description
     case id
+    case apiID = "_id"
     case name, quoteCount, slug, quotesCount
     case dateAdded, dateModified
     case quotes
@@ -45,7 +46,8 @@ extension Author {
   public init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
 
-    id = try container.decode(String.self, forKey: .id)
+    id = try container.decodeIfPresent(String.self, forKey: .id)
+      ?? container.decode(String.self, forKey: .apiID)
     name = try container.decode(String.self, forKey: .name)
     slug = try container.decode(String.self, forKey: .slug)
 
@@ -65,6 +67,21 @@ extension Author {
     dateAdded = (try? container.decode(String.self, forKey: .dateAdded)) ?? ""
     dateModified = (try? container.decode(String.self, forKey: .dateModified)) ?? ""
     quotes = try? container.decode([Quote].self, forKey: .quotes)
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+
+    try container.encode(id, forKey: .id)
+    try container.encode(link, forKey: .link)
+    try container.encode(bio, forKey: .bio)
+    try container.encode(description, forKey: .description)
+    try container.encode(name, forKey: .name)
+    try container.encode(quoteCount, forKey: .quoteCount)
+    try container.encode(slug, forKey: .slug)
+    try container.encode(dateAdded, forKey: .dateAdded)
+    try container.encode(dateModified, forKey: .dateModified)
+    try container.encodeIfPresent(quotes, forKey: .quotes)
   }
 }
 

--- a/Sources/QuoteKit/Model/Quote.swift
+++ b/Sources/QuoteKit/Model/Quote.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct Quote: Identifiable, Equatable, Decodable, Sendable {
+public struct Quote: Identifiable, Equatable, Codable, Sendable {
   public var id: String
   public var tags: [String]
   public var content: String
@@ -35,6 +35,7 @@ public struct Quote: Identifiable, Equatable, Decodable, Sendable {
 extension Quote {
   enum CodingKeys: String, CodingKey {
     case id
+    case apiID = "_id"
     case tags, content, author, authorSlug, length, dateAdded, dateModified
     case name, slug
   }
@@ -42,28 +43,48 @@ extension Quote {
   public init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
 
-    id = try container.decode(String.self, forKey: .id)
+    id = try container.decodeIfPresent(String.self, forKey: .id)
+      ?? container.decode(String.self, forKey: .apiID)
     content = try container.decode(String.self, forKey: .content)
-    length = content.count
+    length = try container.decodeIfPresent(Int.self, forKey: .length) ?? content.count
 
-    // Handle nested author object
-    let authorContainer = try container.nestedContainer(keyedBy: CodingKeys.self, forKey: .author)
-    author = try authorContainer.decode(String.self, forKey: .name)
-    authorSlug = try authorContainer.decode(String.self, forKey: .slug)
-
-    // Handle tags array with nested name property
-    var tagsArray: [String] = []
-    var tagsContainer = try container.nestedUnkeyedContainer(forKey: .tags)
-    while !tagsContainer.isAtEnd {
-      let tagContainer = try tagsContainer.nestedContainer(keyedBy: CodingKeys.self)
-      let tagName = try tagContainer.decode(String.self, forKey: .name)
-      tagsArray.append(tagName)
+    if let authorName = try? container.decode(String.self, forKey: .author) {
+      author = authorName
+      authorSlug = try container.decodeIfPresent(String.self, forKey: .authorSlug) ?? ""
+    } else {
+      let authorContainer = try container.nestedContainer(keyedBy: CodingKeys.self, forKey: .author)
+      author = try authorContainer.decode(String.self, forKey: .name)
+      authorSlug = try authorContainer.decode(String.self, forKey: .slug)
     }
-    tags = tagsArray
 
-    // Optional fields with defaults
+    if let tagNames = try? container.decode([String].self, forKey: .tags) {
+      tags = tagNames
+    } else {
+      var tagNames: [String] = []
+      var tagsContainer = try container.nestedUnkeyedContainer(forKey: .tags)
+      while !tagsContainer.isAtEnd {
+        let tagContainer = try tagsContainer.nestedContainer(keyedBy: CodingKeys.self)
+        let tagName = try tagContainer.decode(String.self, forKey: .name)
+        tagNames.append(tagName.lowercased().replacingOccurrences(of: " ", with: "-"))
+      }
+      tags = tagNames
+    }
+
     dateAdded = (try? container.decode(String.self, forKey: .dateAdded)) ?? ""
     dateModified = (try? container.decode(String.self, forKey: .dateModified)) ?? ""
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+
+    try container.encode(id, forKey: .id)
+    try container.encode(tags, forKey: .tags)
+    try container.encode(content, forKey: .content)
+    try container.encode(author, forKey: .author)
+    try container.encode(authorSlug, forKey: .authorSlug)
+    try container.encode(length, forKey: .length)
+    try container.encode(dateAdded, forKey: .dateAdded)
+    try container.encode(dateModified, forKey: .dateModified)
   }
 }
 

--- a/Sources/QuoteKit/Model/QuoteItemCollection.swift
+++ b/Sources/QuoteKit/Model/QuoteItemCollection.swift
@@ -95,16 +95,54 @@ public struct QuoteItemCollection<Item: Decodable & Sendable>: Decodable, Sendab
     self.results = results
   }
 
+  enum CodingKeys: String, CodingKey {
+    case count
+    case totalCount
+    case totalCountSnakeCase = "total_count"
+    case page
+    case totalPages
+    case totalPagesSnakeCase = "total_pages"
+    case lastItemIndex
+    case lastItemIndexSnakeCase = "last_item_index"
+    case results
+  }
+
   // MARK: - Decodable
 
   public init(from decoder: Decoder) throws {
-    let response = try APIResponse<Item>(from: decoder)
+    if let response = try? APIResponse<Item>(from: decoder) {
+      self.count = response.data.count
+      self.totalCount = response.metadata.total
+      self.page = response.metadata.page + 1 // Convert 0-based to 1-based
+      self.totalPages = response.metadata.lastPage + 1 // Convert 0-based to 1-based
+      self.lastItemIndex = nil // Not provided by API
+      self.results = response.data
+      return
+    }
 
-    self.count = response.data.count
-    self.totalCount = response.metadata.total
-    self.page = response.metadata.page + 1 // Convert 0-based to 1-based
-    self.totalPages = response.metadata.lastPage + 1 // Convert 0-based to 1-based
-    self.lastItemIndex = nil // Not provided by API
-    self.results = response.data
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+
+    self.count = try container.decode(Int.self, forKey: .count)
+    self.totalCount = try container.decodeIfPresent(Int.self, forKey: .totalCount)
+      ?? container.decode(Int.self, forKey: .totalCountSnakeCase)
+    self.page = try container.decode(Int.self, forKey: .page)
+    self.totalPages = try container.decodeIfPresent(Int.self, forKey: .totalPages)
+      ?? container.decode(Int.self, forKey: .totalPagesSnakeCase)
+    self.lastItemIndex = try container.decodeIfPresent(Int.self, forKey: .lastItemIndex)
+      ?? container.decodeIfPresent(Int.self, forKey: .lastItemIndexSnakeCase)
+    self.results = try container.decode([Item].self, forKey: .results)
+  }
+}
+
+extension QuoteItemCollection: Encodable where Item: Encodable {
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+
+    try container.encode(count, forKey: .count)
+    try container.encode(totalCount, forKey: .totalCount)
+    try container.encode(page, forKey: .page)
+    try container.encode(totalPages, forKey: .totalPages)
+    try container.encodeIfPresent(lastItemIndex, forKey: .lastItemIndex)
+    try container.encode(results, forKey: .results)
   }
 }

--- a/Sources/QuoteKit/Model/Tags.swift
+++ b/Sources/QuoteKit/Model/Tags.swift
@@ -63,6 +63,7 @@ public struct Tag: Identifiable, Hashable, Equatable, Sendable {
 extension Tag: Decodable {
   enum CodingKeys: String, CodingKey {
     case id
+    case apiID = "_id"
     case name, dateAdded, dateModified
     case quoteCount, quotesCount
   }
@@ -70,7 +71,8 @@ extension Tag: Decodable {
   public init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
 
-    id = try container.decode(String.self, forKey: .id)
+    id = try container.decodeIfPresent(String.self, forKey: .id)
+      ?? container.decode(String.self, forKey: .apiID)
     name = try container.decode(String.self, forKey: .name)
 
     // Handle both quoteCount (original) and quotesCount (backup) field names

--- a/Tests/QuoteKitTests/QuotableURLHost.swift
+++ b/Tests/QuoteKitTests/QuotableURLHost.swift
@@ -10,7 +10,8 @@ import XCTest
 
 extension QuotableURLHost {
   func expectedURL(with path: String) throws -> URL {
-    let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+    let apiPath = rawValue == "api.quotable.kurokeita.dev" ? "api/" + path : path
+    let encodedPath = apiPath.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
 
     let url = URL(string: "https://" + rawValue + "/" + encodedPath)
     return try XCTUnwrap(url)


### PR DESCRIPTION
## Summary
- make Quote and Author codable while accepting both original Quotable and backup API payload shapes
- decode QuoteItemCollection from both backup pagination envelopes and encoded collection payloads
- unwrap the backup random quote response and align URL/tag expectations with the default backend

## Validation
- swift test
- swift build
- git diff --check