### PR TITLE
Preserve wrapped QuoteItemCollection decoding errors

### DIFF
--- a/Sources/QuoteKit/Model/QuoteItemCollection.swift
+++ b/Sources/QuoteKit/Model/QuoteItemCollection.swift
@@ -48,6 +48,11 @@ private struct APIResponse<Item: Decodable>: Decodable {
   let data: [Item]
   let metadata: Metadata
 
+  enum CodingKeys: String, CodingKey {
+    case data
+    case metadata
+  }
+
   struct Metadata: Decodable {
     let total: Int
     let page: Int
@@ -110,7 +115,9 @@ public struct QuoteItemCollection<Item: Decodable & Sendable>: Decodable, Sendab
   // MARK: - Decodable
 
   public init(from decoder: Decoder) throws {
-    if let response = try? APIResponse<Item>(from: decoder) {
+    let responseContainer = try decoder.container(keyedBy: APIResponse<Item>.CodingKeys.self)
+    if responseContainer.contains(.data) || responseContainer.contains(.metadata) {
+      let response = try APIResponse<Item>(from: decoder)
       self.count = response.data.count
       self.totalCount = response.metadata.total
       self.page = response.metadata.page + 1 // Convert 0-based to 1-based

--- a/Tests/QuoteKitTests/Models/QuoteItemCollectionDecodingTests.swift
+++ b/Tests/QuoteKitTests/Models/QuoteItemCollectionDecodingTests.swift
@@ -1,0 +1,86 @@
+//
+//  QuoteItemCollectionDecodingTests.swift
+//  QuoteKitTests
+//
+//  Created by Assistant on 02/07/2026.
+//
+
+import Foundation
+import Testing
+
+@testable import QuoteKit
+
+@Suite("QuoteItemCollection Decoding Tests")
+struct QuoteItemCollectionDecodingTests {
+    @Test func testDecodesWrappedAPIResponse() throws {
+        let jsonString = """
+        {
+            "data": [
+                {
+                    "_id": "wrapped-quote",
+                    "tags": ["wisdom"],
+                    "content": "Wrapped response content",
+                    "author": "Wrapped Author",
+                    "authorSlug": "wrapped-author",
+                    "length": 24,
+                    "dateAdded": "2025-01-01T00:00:00Z",
+                    "dateModified": "2025-01-02T00:00:00Z"
+                }
+            ],
+            "metadata": {
+                "total": 12,
+                "page": 0,
+                "lastPage": 3,
+                "hasNextPage": true,
+                "hasPreviousPage": false
+            }
+        }
+        """
+
+        let jsonData = jsonString.data(using: .utf8)!
+        let decoder = JSONDecoder()
+
+        let collection = try decoder.decode(QuoteItemCollection<Quote>.self, from: jsonData)
+
+        #expect(collection.count == 1)
+        #expect(collection.totalCount == 12)
+        #expect(collection.page == 1)
+        #expect(collection.totalPages == 4)
+        #expect(collection.lastItemIndex == nil)
+        #expect(collection.results.first?.id == "wrapped-quote")
+    }
+
+    @Test func testPreservesWrappedItemDecodingFailure() throws {
+        let jsonString = """
+        {
+            "data": [
+                {
+                    "_id": "malformed-quote",
+                    "tags": ["wisdom"],
+                    "author": "Wrapped Author",
+                    "authorSlug": "wrapped-author"
+                }
+            ],
+            "metadata": {
+                "total": 1,
+                "page": 0,
+                "lastPage": 0,
+                "hasNextPage": false,
+                "hasPreviousPage": false
+            }
+        }
+        """
+
+        let jsonData = jsonString.data(using: .utf8)!
+        let decoder = JSONDecoder()
+
+        do {
+            _ = try decoder.decode(QuoteItemCollection<Quote>.self, from: jsonData)
+            Issue.record("Expected wrapped item decoding to fail.")
+        } catch DecodingError.keyNotFound(let key, _) {
+            #expect(key.stringValue == "content")
+        } catch {
+            Issue.record("Expected missing content to be preserved, got \\(error).")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- detect the wrapped data/metadata response shape before decoding it
- preserve real wrapped item decoding failures instead of falling back to legacy count/results decoding
- add focused wrapper success and malformed-item regression tests

## Tests
- swift test --filter QuoteItemCollectionDecodingTests
- swift test
- swift package clean && swift test

## Notes
- local main was stale by 2 commits, so this branch was created from fetched origin/main (a55c9d4) in a separate worktree